### PR TITLE
Add catalog API module with categories and products

### DIFF
--- a/app/DTO/Category/StoreCategoryDto.php
+++ b/app/DTO/Category/StoreCategoryDto.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\DTO\Category;
+
+use App\Http\Requests\Category\StoreCategoryRequest;
+
+final readonly class StoreCategoryDto
+{
+    public function __construct(
+        public string $name,
+        public ?string $slug,
+        public ?int $parentId,
+        public bool $isActive,
+    ) {
+    }
+
+    public static function fromRequest(StoreCategoryRequest $request): self
+    {
+        $validated = $request->validated();
+
+        return new self(
+            name: $validated['name'],
+            slug: $validated['slug'] ?? null,
+            parentId: $validated['parent_id'] ?? null,
+            isActive: $validated['is_active'] ?? true,
+        );
+    }
+}

--- a/app/DTO/Category/UpdateCategoryDto.php
+++ b/app/DTO/Category/UpdateCategoryDto.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\DTO\Category;
+
+use App\Http\Requests\Category\UpdateCategoryRequest;
+use App\Models\Category;
+
+final readonly class UpdateCategoryDto
+{
+    public function __construct(
+        public string $name,
+        public ?string $slug,
+        public ?int $parentId,
+        public bool $isActive,
+    ) {
+    }
+
+    public static function fromRequest(UpdateCategoryRequest $request, Category $category): self
+    {
+        $validated = $request->validated();
+
+        return new self(
+            name: $validated['name'] ?? $category->name,
+            slug: $validated['slug'] ?? $category->slug,
+            parentId: $validated['parent_id'] ?? $category->parent_id,
+            isActive: $validated['is_active'] ?? $category->is_active,
+        );
+    }
+}

--- a/app/DTO/Product/StoreProductDto.php
+++ b/app/DTO/Product/StoreProductDto.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\DTO\Product;
+
+use App\Http\Requests\Product\StoreProductRequest;
+
+final readonly class StoreProductDto
+{
+    public function __construct(
+        public int $categoryId,
+        public string $name,
+        public ?string $slug,
+        public string $sku,
+        public float $price,
+        public string $currency,
+        public int $quantity,
+        public bool $isActive,
+        public ?string $description,
+    ) {
+    }
+
+    public static function fromRequest(StoreProductRequest $request): self
+    {
+        $validated = $request->validated();
+
+        return new self(
+            categoryId: $validated['category_id'],
+            name: $validated['name'],
+            slug: $validated['slug'] ?? null,
+            sku: $validated['sku'],
+            price: (float) $validated['price'],
+            currency: $validated['currency'] ?? 'AMD',
+            quantity: $validated['quantity'] ?? 0,
+            isActive: $validated['is_active'] ?? true,
+            description: $validated['description'] ?? null,
+        );
+    }
+}

--- a/app/DTO/Product/UpdateProductDto.php
+++ b/app/DTO/Product/UpdateProductDto.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\DTO\Product;
+
+use App\Http\Requests\Product\UpdateProductRequest;
+use App\Models\Product;
+
+final readonly class UpdateProductDto
+{
+    public function __construct(
+        public int $categoryId,
+        public string $name,
+        public ?string $slug,
+        public string $sku,
+        public float $price,
+        public string $currency,
+        public int $quantity,
+        public bool $isActive,
+        public ?string $description,
+    ) {
+    }
+
+    public static function fromRequest(UpdateProductRequest $request, Product $product): self
+    {
+        $validated = $request->validated();
+
+        return new self(
+            categoryId: $validated['category_id'] ?? $product->category_id,
+            name: $validated['name'] ?? $product->name,
+            slug: $validated['slug'] ?? $product->slug,
+            sku: $validated['sku'] ?? $product->sku,
+            price: isset($validated['price']) ? (float) $validated['price'] : (float) $product->price,
+            currency: $validated['currency'] ?? $product->currency,
+            quantity: $validated['quantity'] ?? $product->quantity,
+            isActive: $validated['is_active'] ?? $product->is_active,
+            description: array_key_exists('description', $validated) ? $validated['description'] : $product->description,
+        );
+    }
+}

--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\DTO\Category\StoreCategoryDto;
+use App\DTO\Category\UpdateCategoryDto;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Category\StoreCategoryRequest;
+use App\Http\Requests\Category\UpdateCategoryRequest;
+use App\Http\Resources\CategoryResource;
+use App\Models\Category;
+use App\Services\CategoryService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class CategoryController extends Controller
+{
+    public function __construct(private readonly CategoryService $categoryService)
+    {
+    }
+
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $perPage = (int) $request->integer('per_page', 15);
+        $perPage = max(1, min($perPage, 100));
+
+        $categories = $this->categoryService->paginate($perPage);
+
+        return CategoryResource::collection($categories);
+    }
+
+    public function store(StoreCategoryRequest $request): JsonResponse
+    {
+        $dto = StoreCategoryDto::fromRequest($request);
+
+        $category = $this->categoryService->create($dto);
+
+        return CategoryResource::make($category)->response()->setStatusCode(201);
+    }
+
+    public function show(Category $category): CategoryResource
+    {
+        return CategoryResource::make($category->load('children'));
+    }
+
+    public function update(UpdateCategoryRequest $request, Category $category): CategoryResource
+    {
+        $dto = UpdateCategoryDto::fromRequest($request, $category);
+
+        $updated = $this->categoryService->update($category, $dto);
+
+        return CategoryResource::make($updated);
+    }
+
+    public function destroy(Category $category): JsonResponse
+    {
+        $this->categoryService->delete($category);
+
+        return response()->noContent();
+    }
+
+    public function tree(): JsonResponse
+    {
+        return response()->json($this->categoryService->tree());
+    }
+}

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\DTO\Product\StoreProductDto;
+use App\DTO\Product\UpdateProductDto;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Product\StoreProductRequest;
+use App\Http\Requests\Product\UpdateProductRequest;
+use App\Http\Resources\ProductCollection;
+use App\Http\Resources\ProductResource;
+use App\Models\Product;
+use App\Services\ProductService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    public function __construct(private readonly ProductService $productService)
+    {
+    }
+
+    public function index(Request $request): ProductCollection
+    {
+        $perPage = (int) $request->integer('per_page', 15);
+        $perPage = max(1, min($perPage, 100));
+
+        $filters = $request->only([
+            'search',
+            'category_id',
+            'is_active',
+            'price_min',
+            'price_max',
+            'sort',
+        ]);
+
+        $normalizedFilters = [];
+        foreach ($filters as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+            if ($value === '' && $value !== '0') {
+                continue;
+            }
+            $normalizedFilters[$key] = $value;
+        }
+
+        $products = $this->productService->paginate($normalizedFilters, $perPage);
+
+        return new ProductCollection($products);
+    }
+
+    public function store(StoreProductRequest $request): JsonResponse
+    {
+        $dto = StoreProductDto::fromRequest($request);
+
+        $product = $this->productService->create($dto);
+
+        return ProductResource::make($product)->response()->setStatusCode(201);
+    }
+
+    public function show(Product $product): ProductResource
+    {
+        return ProductResource::make($product->load('category'));
+    }
+
+    public function update(UpdateProductRequest $request, Product $product): ProductResource
+    {
+        $dto = UpdateProductDto::fromRequest($request, $product);
+
+        $updated = $this->productService->update($product, $dto);
+
+        return ProductResource::make($updated);
+    }
+
+    public function destroy(Product $product): JsonResponse
+    {
+        $this->productService->delete($product);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Category/StoreCategoryRequest.php
+++ b/app/Http/Requests/Category/StoreCategoryRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Category;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:191', Rule::unique('categories', 'name')],
+            'slug' => ['nullable', 'string', 'max:191', Rule::unique('categories', 'slug')],
+            'parent_id' => ['nullable', 'exists:categories,id', 'different:id'],
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Category/UpdateCategoryRequest.php
+++ b/app/Http/Requests/Category/UpdateCategoryRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Category;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $categoryId = $this->route('category')?->id;
+
+        $parentRules = ['nullable', 'exists:categories,id', 'different:id'];
+        if ($categoryId !== null) {
+            $parentRules[] = Rule::notIn([$categoryId]);
+        }
+
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:191', Rule::unique('categories', 'name')->ignore($categoryId)],
+            'slug' => ['nullable', 'string', 'max:191', Rule::unique('categories', 'slug')->ignore($categoryId)],
+            'parent_id' => $parentRules,
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Product/StoreProductRequest.php
+++ b/app/Http/Requests/Product/StoreProductRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'category_id' => ['required', 'exists:categories,id'],
+            'name' => ['required', 'string', 'max:191'],
+            'slug' => ['nullable', 'string', 'max:191', Rule::unique('products', 'slug')],
+            'sku' => ['required', 'string', 'max:64', Rule::unique('products', 'sku')],
+            'price' => ['required', 'numeric', 'min:0'],
+            'currency' => ['sometimes', 'string', 'size:3'],
+            'quantity' => ['sometimes', 'integer', 'min:0'],
+            'is_active' => ['sometimes', 'boolean'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Product/UpdateProductRequest.php
+++ b/app/Http/Requests/Product/UpdateProductRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Product;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $productId = $this->route('product')?->id;
+
+        return [
+            'category_id' => ['sometimes', 'required', 'exists:categories,id'],
+            'name' => ['sometimes', 'required', 'string', 'max:191'],
+            'slug' => ['nullable', 'string', 'max:191', Rule::unique('products', 'slug')->ignore($productId)],
+            'sku' => ['sometimes', 'required', 'string', 'max:64', Rule::unique('products', 'sku')->ignore($productId)],
+            'price' => ['sometimes', 'required', 'numeric', 'min:0'],
+            'currency' => ['sometimes', 'string', 'size:3'],
+            'quantity' => ['sometimes', 'integer', 'min:0'],
+            'is_active' => ['sometimes', 'boolean'],
+            'description' => ['sometimes', 'nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Resources/CategoryResource.php
+++ b/app/Http/Resources/CategoryResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Category
+ */
+class CategoryResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'parent_id' => $this->parent_id,
+            'is_active' => (bool) $this->is_active,
+            'children' => $this->whenLoaded('children', function () use ($request) {
+                return CategoryResource::collection($this->children)->toArray($request);
+            }, []),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/ProductCollection.php
+++ b/app/Http/Resources/ProductCollection.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class ProductCollection extends ResourceCollection
+{
+    public $collects = ProductResource::class;
+
+    public function toArray($request): array
+    {
+        $data = $this->collection->map(function ($resource) use ($request) {
+            return $resource instanceof ProductResource
+                ? $resource->toArray($request)
+                : (new ProductResource($resource))->toArray($request);
+        })->all();
+
+        $paginator = $this->resource instanceof LengthAwarePaginator ? $this->resource : null;
+
+        return [
+            'data' => $data,
+            'meta' => $paginator ? [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ] : [
+                'current_page' => 1,
+                'per_page' => count($data),
+                'total' => count($data),
+                'last_page' => 1,
+            ],
+            'links' => $paginator ? [
+                'first' => $paginator->url(1),
+                'last' => $paginator->url($paginator->lastPage()),
+                'prev' => $paginator->previousPageUrl(),
+                'next' => $paginator->nextPageUrl(),
+            ] : [
+                'first' => null,
+                'last' => null,
+                'prev' => null,
+                'next' => null,
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/ProductResource.php
+++ b/app/Http/Resources/ProductResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Product
+ */
+class ProductResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'sku' => $this->sku,
+            'price' => (float) $this->price,
+            'currency' => $this->currency,
+            'quantity' => (int) $this->quantity,
+            'is_active' => (bool) $this->is_active,
+            'description' => $this->description,
+            'category' => $this->whenLoaded('category', function () {
+                return [
+                    'id' => $this->category->id,
+                    'name' => $this->category->name,
+                    'slug' => $this->category->slug,
+                ];
+            }),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Category extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'parent_id',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Product extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'category_id',
+        'name',
+        'slug',
+        'sku',
+        'price',
+        'currency',
+        'quantity',
+        'is_active',
+        'description',
+    ];
+
+    protected $casts = [
+        'price' => 'float',
+        'quantity' => 'integer',
+        'is_active' => 'boolean',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Repositories\Eloquent\CategoryRepository;
+use App\Repositories\Eloquent\ProductRepository;
+use App\Repositories\Interfaces\CategoryRepositoryInterface;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +15,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(CategoryRepositoryInterface::class, CategoryRepository::class);
+        $this->app->bind(ProductRepositoryInterface::class, ProductRepository::class);
     }
 
     /**

--- a/app/Repositories/Eloquent/CategoryRepository.php
+++ b/app/Repositories/Eloquent/CategoryRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+
+use App\DTO\Category\StoreCategoryDto;
+use App\DTO\Category\UpdateCategoryDto;
+use App\Models\Category;
+use App\Repositories\Interfaces\CategoryRepositoryInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+
+class CategoryRepository implements CategoryRepositoryInterface
+{
+    public function paginate(int $perPage = 15): LengthAwarePaginator
+    {
+        return Category::query()->with('children')->paginate($perPage);
+    }
+
+    public function findById(int $id): Category
+    {
+        return Category::query()->with('children')->findOrFail($id);
+    }
+
+    public function create(StoreCategoryDto $dto): Category
+    {
+        $category = Category::query()->create([
+            'name' => $dto->name,
+            'slug' => $dto->slug,
+            'parent_id' => $dto->parentId,
+            'is_active' => $dto->isActive,
+        ]);
+
+        return $category->load('children');
+    }
+
+    public function update(Category $category, UpdateCategoryDto $dto): Category
+    {
+        $category->update([
+            'name' => $dto->name,
+            'slug' => $dto->slug,
+            'parent_id' => $dto->parentId,
+            'is_active' => $dto->isActive,
+        ]);
+
+        return $category->load('children');
+    }
+
+    public function delete(Category $category): void
+    {
+        $category->delete();
+    }
+
+    public function tree(): array
+    {
+        $categories = Category::query()
+            ->where('is_active', true)
+            ->with(['children' => function ($query) {
+                $query->where('is_active', true);
+            }])
+            ->orderBy('name')
+            ->get();
+
+        return $this->buildTree($categories);
+    }
+
+    private function buildTree(Collection $categories, ?int $parentId = null): array
+    {
+        return $categories
+            ->where('parent_id', $parentId)
+            ->map(function (Category $category) use ($categories) {
+                return [
+                    'id' => $category->id,
+                    'name' => $category->name,
+                    'slug' => $category->slug,
+                    'parent_id' => $category->parent_id,
+                    'is_active' => (bool) $category->is_active,
+                    'children' => $this->buildTree($categories, $category->id),
+                ];
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/app/Repositories/Eloquent/ProductRepository.php
+++ b/app/Repositories/Eloquent/ProductRepository.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Repositories\Eloquent;
+
+use App\DTO\Product\StoreProductDto;
+use App\DTO\Product\UpdateProductDto;
+use App\Models\Product;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+class ProductRepository implements ProductRepositoryInterface
+{
+    public function paginate(int $perPage = 15): LengthAwarePaginator
+    {
+        return Product::query()->with('category')->paginate($perPage);
+    }
+
+    public function filterPaginate(array $filters, int $perPage = 15): LengthAwarePaginator
+    {
+        $query = Product::query()->with('category');
+
+        $query = $this->applyFilters($query, $filters);
+
+        $perPage = max(1, min($perPage, 100));
+
+        return $query->paginate($perPage)->appends($filters);
+    }
+
+    public function findById(int $id): Product
+    {
+        return Product::query()->with('category')->findOrFail($id);
+    }
+
+    public function create(StoreProductDto $dto): Product
+    {
+        $product = Product::query()->create([
+            'category_id' => $dto->categoryId,
+            'name' => $dto->name,
+            'slug' => $dto->slug,
+            'sku' => $dto->sku,
+            'price' => $dto->price,
+            'currency' => $dto->currency,
+            'quantity' => $dto->quantity,
+            'is_active' => $dto->isActive,
+            'description' => $dto->description,
+        ]);
+
+        return $product->load('category');
+    }
+
+    public function update(Product $product, UpdateProductDto $dto): Product
+    {
+        $product->update([
+            'category_id' => $dto->categoryId,
+            'name' => $dto->name,
+            'slug' => $dto->slug,
+            'sku' => $dto->sku,
+            'price' => $dto->price,
+            'currency' => $dto->currency,
+            'quantity' => $dto->quantity,
+            'is_active' => $dto->isActive,
+            'description' => $dto->description,
+        ]);
+
+        return $product->load('category');
+    }
+
+    public function delete(Product $product): void
+    {
+        $product->delete();
+    }
+
+    private function applyFilters(Builder $query, array $filters): Builder
+    {
+        if (!empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->where(function (Builder $builder) use ($search) {
+                $builder
+                    ->where('name', 'like', "%{$search}%")
+                    ->orWhere('sku', 'like', "%{$search}%")
+                    ->orWhere('slug', 'like', "%{$search}%");
+            });
+        }
+
+        if (!empty($filters['category_id'])) {
+            $query->where('category_id', $filters['category_id']);
+        }
+
+        if (array_key_exists('is_active', $filters) && $filters['is_active'] !== null && $filters['is_active'] !== '') {
+            $query->where('is_active', (bool) $filters['is_active']);
+        }
+
+        if (array_key_exists('price_min', $filters) && $filters['price_min'] !== null && $filters['price_min'] !== '') {
+            $query->where('price', '>=', $filters['price_min']);
+        }
+
+        if (array_key_exists('price_max', $filters) && $filters['price_max'] !== null && $filters['price_max'] !== '') {
+            $query->where('price', '<=', $filters['price_max']);
+        }
+
+        if (!empty($filters['sort'])) {
+            $this->applySort($query, $filters['sort']);
+        } else {
+            $query->orderByDesc('created_at');
+        }
+
+        return $query;
+    }
+
+    private function applySort(Builder $query, string $sort): void
+    {
+        $fields = array_map('trim', explode(',', $sort));
+        $allowed = ['name', 'price', 'created_at', 'quantity'];
+
+        foreach ($fields as $field) {
+            if ($field === '') {
+                continue;
+            }
+
+            $direction = str_starts_with($field, '-') ? 'desc' : 'asc';
+            $column = ltrim($field, '-');
+
+            if (in_array($column, $allowed, true)) {
+                $query->orderBy($column, $direction);
+            }
+        }
+    }
+}

--- a/app/Repositories/Interfaces/CategoryRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CategoryRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+use App\DTO\Category\StoreCategoryDto;
+use App\DTO\Category\UpdateCategoryDto;
+use App\Models\Category;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+interface CategoryRepositoryInterface
+{
+    public function paginate(int $perPage = 15): LengthAwarePaginator;
+
+    public function findById(int $id): Category;
+
+    public function create(StoreCategoryDto $dto): Category;
+
+    public function update(Category $category, UpdateCategoryDto $dto): Category;
+
+    public function delete(Category $category): void;
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function tree(): array;
+}

--- a/app/Repositories/Interfaces/ProductRepositoryInterface.php
+++ b/app/Repositories/Interfaces/ProductRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+use App\DTO\Product\StoreProductDto;
+use App\DTO\Product\UpdateProductDto;
+use App\Models\Product;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+interface ProductRepositoryInterface
+{
+    public function paginate(int $perPage = 15): LengthAwarePaginator;
+
+    public function filterPaginate(array $filters, int $perPage = 15): LengthAwarePaginator;
+
+    public function findById(int $id): Product;
+
+    public function create(StoreProductDto $dto): Product;
+
+    public function update(Product $product, UpdateProductDto $dto): Product;
+
+    public function delete(Product $product): void;
+}

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services;
+
+use App\DTO\Category\StoreCategoryDto;
+use App\DTO\Category\UpdateCategoryDto;
+use App\Models\Category;
+use App\Repositories\Interfaces\CategoryRepositoryInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
+
+class CategoryService
+{
+    public function __construct(private readonly CategoryRepositoryInterface $categoryRepository)
+    {
+    }
+
+    public function paginate(int $perPage = 15): LengthAwarePaginator
+    {
+        return $this->categoryRepository->paginate($perPage);
+    }
+
+    public function find(int $id): Category
+    {
+        return $this->categoryRepository->findById($id);
+    }
+
+    public function create(StoreCategoryDto $dto): Category
+    {
+        $slug = $this->prepareSlug($dto->slug, $dto->name);
+
+        $preparedDto = new StoreCategoryDto(
+            name: $dto->name,
+            slug: $slug,
+            parentId: $dto->parentId,
+            isActive: $dto->isActive,
+        );
+
+        return $this->categoryRepository->create($preparedDto);
+    }
+
+    public function update(Category $category, UpdateCategoryDto $dto): Category
+    {
+        $slug = $this->prepareSlug($dto->slug, $dto->name, $category->id);
+
+        $preparedDto = new UpdateCategoryDto(
+            name: $dto->name,
+            slug: $slug,
+            parentId: $dto->parentId,
+            isActive: $dto->isActive,
+        );
+
+        return $this->categoryRepository->update($category, $preparedDto);
+    }
+
+    public function delete(Category $category): void
+    {
+        $this->categoryRepository->delete($category);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function tree(): array
+    {
+        return $this->categoryRepository->tree();
+    }
+
+    private function prepareSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        $baseSlug = $slug ? Str::slug($slug) : Str::slug($name);
+        if ($baseSlug === '' || $baseSlug === null) {
+            $baseSlug = Str::uuid()->toString();
+        }
+
+        $uniqueSlug = $baseSlug;
+        $counter = 1;
+
+        while ($this->slugExists($uniqueSlug, $ignoreId)) {
+            $uniqueSlug = $baseSlug.'-'.$counter++;
+        }
+
+        return $uniqueSlug;
+    }
+
+    private function slugExists(string $slug, ?int $ignoreId = null): bool
+    {
+        $query = Category::withTrashed()->where('slug', $slug);
+        if ($ignoreId !== null) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        return $query->exists();
+    }
+}

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Services;
+
+use App\DTO\Product\StoreProductDto;
+use App\DTO\Product\UpdateProductDto;
+use App\Models\Product;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
+
+class ProductService
+{
+    public function __construct(private readonly ProductRepositoryInterface $productRepository)
+    {
+    }
+
+    public function paginate(array $filters = [], int $perPage = 15): LengthAwarePaginator
+    {
+        if ($filters === []) {
+            return $this->productRepository->paginate($perPage);
+        }
+
+        return $this->productRepository->filterPaginate($filters, $perPage);
+    }
+
+    public function find(int $id): Product
+    {
+        return $this->productRepository->findById($id);
+    }
+
+    public function create(StoreProductDto $dto): Product
+    {
+        $slug = $this->prepareSlug($dto->slug, $dto->name);
+
+        $preparedDto = new StoreProductDto(
+            categoryId: $dto->categoryId,
+            name: $dto->name,
+            slug: $slug,
+            sku: $dto->sku,
+            price: $dto->price,
+            currency: $dto->currency,
+            quantity: $dto->quantity,
+            isActive: $dto->isActive,
+            description: $dto->description,
+        );
+
+        return $this->productRepository->create($preparedDto);
+    }
+
+    public function update(Product $product, UpdateProductDto $dto): Product
+    {
+        $slug = $this->prepareSlug($dto->slug, $dto->name, $product->id);
+
+        $preparedDto = new UpdateProductDto(
+            categoryId: $dto->categoryId,
+            name: $dto->name,
+            slug: $slug,
+            sku: $dto->sku,
+            price: $dto->price,
+            currency: $dto->currency,
+            quantity: $dto->quantity,
+            isActive: $dto->isActive,
+            description: $dto->description,
+        );
+
+        return $this->productRepository->update($product, $preparedDto);
+    }
+
+    public function delete(Product $product): void
+    {
+        $this->productRepository->delete($product);
+    }
+
+    private function prepareSlug(?string $slug, string $name, ?int $ignoreId = null): string
+    {
+        $baseSlug = $slug ? Str::slug($slug) : Str::slug($name);
+        if ($baseSlug === '' || $baseSlug === null) {
+            $baseSlug = Str::uuid()->toString();
+        }
+
+        $uniqueSlug = $baseSlug;
+        $counter = 1;
+
+        while ($this->slugExists($uniqueSlug, $ignoreId)) {
+            $uniqueSlug = $baseSlug.'-'.$counter++;
+        }
+
+        return $uniqueSlug;
+    }
+
+    private function slugExists(string $slug, ?int $ignoreId = null): bool
+    {
+        $query = Product::withTrashed()->where('slug', $slug);
+        if ($ignoreId !== null) {
+            $query->where('id', '!=', $ignoreId);
+        }
+
+        return $query->exists();
+    }
+}

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1, 9999),
+            'parent_id' => null,
+            'is_active' => $this->faker->boolean(90),
+        ];
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\Product>
+ */
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(3, true);
+
+        return [
+            'category_id' => Category::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1, 99999),
+            'sku' => strtoupper(Str::random(8)).$this->faker->unique()->numberBetween(100, 999),
+            'price' => $this->faker->randomFloat(2, 10, 9999),
+            'currency' => 'AMD',
+            'quantity' => $this->faker->numberBetween(0, 1000),
+            'is_active' => $this->faker->boolean(90),
+            'description' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_categories_table.php
+++ b/database/migrations/2024_01_01_000000_create_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 191)->unique();
+            $table->string('slug', 191)->unique();
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->boolean('is_active')->default(true)->index();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('slug');
+            $table->index('parent_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_01_01_000100_create_products_table.php
+++ b/database/migrations/2024_01_01_000100_create_products_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('categories')->cascadeOnUpdate()->cascadeOnDelete();
+            $table->string('name', 191);
+            $table->string('slug', 191)->unique();
+            $table->string('sku', 64)->unique();
+            $table->decimal('price', 12, 2);
+            $table->string('currency', 3)->default('AMD');
+            $table->unsignedInteger('quantity')->default(0);
+            $table->boolean('is_active')->default(true)->index();
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('category_id');
+            $table->index('slug');
+            $table->index('sku');
+            $table->index(['is_active', 'category_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,4 +2,14 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/test', \App\Http\Controllers\TestController::class);
+Route::prefix('v1')->name('api.v1.')->group(function () {
+    Route::apiResource('categories', \App\Http\Controllers\Api\CategoryController::class);
+
+    Route::get('products', [\App\Http\Controllers\Api\ProductController::class, 'index'])->name('products.index');
+    Route::post('products', [\App\Http\Controllers\Api\ProductController::class, 'store'])->name('products.store');
+    Route::get('products/{product}', [\App\Http\Controllers\Api\ProductController::class, 'show'])->name('products.show');
+    Route::put('products/{product}', [\App\Http\Controllers\Api\ProductController::class, 'update'])->name('products.update');
+    Route::delete('products/{product}', [\App\Http\Controllers\Api\ProductController::class, 'destroy'])->name('products.destroy');
+
+    Route::get('categories-tree', [\App\Http\Controllers\Api\CategoryController::class, 'tree'])->name('categories.tree');
+});

--- a/tests/Feature/Api/CategoryApiTest.php
+++ b/tests/Feature/Api/CategoryApiTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_category(): void
+    {
+        $payload = [
+            'name' => 'Electronics',
+            'is_active' => true,
+        ];
+
+        $response = $this->postJson(route('api.v1.categories.store'), $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', 'Electronics')
+            ->assertJsonPath('data.is_active', true);
+
+        $this->assertDatabaseHas('categories', [
+            'name' => 'Electronics',
+        ]);
+    }
+
+    public function test_it_updates_category(): void
+    {
+        $category = Category::factory()->create([
+            'name' => 'Electronics',
+            'slug' => 'electronics',
+        ]);
+        $parent = Category::factory()->create([
+            'name' => 'Parent',
+            'slug' => 'parent',
+        ]);
+
+        $response = $this->putJson(route('api.v1.categories.update', $category), [
+            'name' => 'Smartphones',
+            'parent_id' => $parent->id,
+            'is_active' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'Smartphones')
+            ->assertJsonPath('data.parent_id', $parent->id)
+            ->assertJsonPath('data.is_active', false);
+
+        $this->assertDatabaseHas('categories', [
+            'id' => $category->id,
+            'name' => 'Smartphones',
+            'parent_id' => $parent->id,
+            'is_active' => false,
+        ]);
+    }
+
+    public function test_it_lists_categories(): void
+    {
+        Category::factory()->count(3)->create();
+
+        $response = $this->getJson(route('api.v1.categories.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_it_deletes_category(): void
+    {
+        $category = Category::factory()->create();
+
+        $response = $this->deleteJson(route('api.v1.categories.destroy', $category));
+
+        $response->assertNoContent();
+
+        $this->assertSoftDeleted('categories', ['id' => $category->id]);
+    }
+
+    public function test_it_returns_tree(): void
+    {
+        $parent = Category::factory()->create([
+            'name' => 'Root',
+            'slug' => 'root-category',
+        ]);
+
+        $child = Category::factory()->create([
+            'name' => 'Child',
+            'slug' => 'child-category',
+            'parent_id' => $parent->id,
+        ]);
+
+        Category::factory()->create([
+            'name' => 'Inactive',
+            'slug' => 'inactive-category',
+            'parent_id' => $parent->id,
+            'is_active' => false,
+        ]);
+
+        $response = $this->getJson(route('api.v1.categories.tree'));
+
+        $response->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.children.0.id', $child->id)
+            ->assertJsonMissing(['slug' => 'inactive-category']);
+    }
+}

--- a/tests/Feature/Api/ProductApiTest.php
+++ b/tests/Feature/Api/ProductApiTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_product(): void
+    {
+        $category = Category::factory()->create();
+
+        $payload = [
+            'category_id' => $category->id,
+            'name' => 'Test Product',
+            'sku' => 'SKU12345',
+            'price' => 199.99,
+            'currency' => 'AMD',
+            'quantity' => 10,
+            'is_active' => true,
+        ];
+
+        $response = $this->postJson(route('api.v1.products.store'), $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.name', 'Test Product')
+            ->assertJsonPath('data.category.id', $category->id);
+
+        $this->assertDatabaseHas('products', [
+            'name' => 'Test Product',
+            'sku' => 'SKU12345',
+        ]);
+    }
+
+    public function test_it_updates_product(): void
+    {
+        $product = Product::factory()->create([
+            'name' => 'Old Name',
+            'sku' => 'OLDSKU12',
+            'price' => 100,
+            'quantity' => 5,
+        ]);
+
+        $response = $this->putJson(route('api.v1.products.update', $product), [
+            'name' => 'New Name',
+            'sku' => 'NEWSKU34',
+            'price' => 150.50,
+            'quantity' => 8,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'New Name')
+            ->assertJsonPath('data.price', 150.5)
+            ->assertJsonPath('data.quantity', 8);
+
+        $this->assertDatabaseHas('products', [
+            'id' => $product->id,
+            'name' => 'New Name',
+            'sku' => 'NEWSKU34',
+            'price' => 150.50,
+        ]);
+    }
+
+    public function test_it_shows_product(): void
+    {
+        $product = Product::factory()->create([
+            'name' => 'Shown Product',
+            'sku' => 'SHOWSKU1',
+        ]);
+
+        $response = $this->getJson(route('api.v1.products.show', $product));
+
+        $response->assertOk()
+            ->assertJsonPath('data.id', $product->id)
+            ->assertJsonPath('data.category.id', $product->category_id);
+    }
+
+    public function test_it_lists_products_with_filters(): void
+    {
+        $categoryA = Category::factory()->create(['name' => 'Category A', 'slug' => 'category-a']);
+        $categoryB = Category::factory()->create(['name' => 'Category B', 'slug' => 'category-b']);
+
+        $matching = Product::factory()->create([
+            'category_id' => $categoryA->id,
+            'name' => 'Alpha Phone',
+            'slug' => 'alpha-phone',
+            'sku' => 'ALPHA001',
+            'price' => 120,
+            'is_active' => true,
+        ]);
+
+        Product::factory()->create([
+            'category_id' => $categoryA->id,
+            'name' => 'Beta Tablet',
+            'slug' => 'beta-tablet',
+            'sku' => 'BETA002',
+            'price' => 220,
+            'is_active' => false,
+        ]);
+
+        Product::factory()->create([
+            'category_id' => $categoryB->id,
+            'name' => 'Gamma Laptop',
+            'slug' => 'gamma-laptop',
+            'sku' => 'GAMMA003',
+            'price' => 320,
+            'is_active' => true,
+        ]);
+
+        $response = $this->getJson(route('api.v1.products.index', [
+            'search' => 'Alpha',
+            'category_id' => $categoryA->id,
+            'is_active' => 1,
+            'price_min' => 100,
+            'price_max' => 150,
+        ]));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $matching->id);
+    }
+
+    public function test_it_sorts_products_by_price_desc(): void
+    {
+        $cheapest = Product::factory()->create(['price' => 100, 'sku' => 'CHEAP001']);
+        $mid = Product::factory()->create(['price' => 200, 'sku' => 'MID001']);
+        $expensive = Product::factory()->create(['price' => 300, 'sku' => 'EXPENS001']);
+
+        $response = $this->getJson(route('api.v1.products.index', ['sort' => '-price']));
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $expensive->id)
+            ->assertJsonPath('data.1.id', $mid->id)
+            ->assertJsonPath('data.2.id', $cheapest->id);
+    }
+
+    public function test_it_deletes_product(): void
+    {
+        $product = Product::factory()->create();
+
+        $response = $this->deleteJson(route('api.v1.products.destroy', $product));
+
+        $response->assertNoContent();
+
+        $this->assertSoftDeleted('products', ['id' => $product->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Category and Product domain models, DTOs, repositories, services, and API controllers
- add product filtering, sorting, pagination plus category tree endpoint with dedicated resources
- provide migrations, factories, and feature tests covering catalog CRUD flows

## Testing
- composer install *(fails: GitHub 403 when downloading packages)*
- php artisan test *(blocked: vendor autoloader missing due to composer failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e17728365083308d63186ad27b53c8