### PR TITLE
Fix API delete responses and stabilize category factory

### DIFF
--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -57,7 +57,7 @@ class CategoryController extends Controller
     {
         $this->categoryService->delete($category);
 
-        return response()->noContent();
+        return response()->json(null, 204);
     }
 
     public function tree(): JsonResponse

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -77,6 +77,6 @@ class ProductController extends Controller
     {
         $this->productService->delete($product);
 
-        return response()->noContent();
+        return response()->json(null, 204);
     }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -21,7 +21,7 @@ class CategoryFactory extends Factory
             'name' => $name,
             'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1, 9999),
             'parent_id' => null,
-            'is_active' => $this->faker->boolean(90),
+            'is_active' => true,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- ensure the category deletion endpoint returns a JSON 204 response to satisfy the API contract
- ensure the product deletion endpoint returns a JSON 204 response to satisfy the API contract
- default generated categories to an active state for deterministic tree responses

## Testing
- not run (composer install requires a GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e17bd296cc83308966846b81f8536a