### PR TITLE
Add catalog factories and database seeder

### DIFF
--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -24,4 +24,25 @@ class CategoryFactory extends Factory
             'is_active' => true,
         ];
     }
+
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => true,
+        ]);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    public function childOf(Category $parent): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'parent_id' => $parent->getKey(),
+        ]);
+    }
 }

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -30,4 +30,39 @@ class ProductFactory extends Factory
             'description' => $this->faker->sentence(),
         ];
     }
+
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => true,
+        ]);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    public function lowStock(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'quantity' => $this->faker->numberBetween(0, 5),
+        ]);
+    }
+
+    public function pricedBetween(float $min, float $max): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'price' => $this->faker->randomFloat(2, $min, $max),
+        ]);
+    }
+
+    public function inCurrency(string $currency): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'currency' => strtoupper($currency),
+        ]);
+    }
 }

--- a/database/seeders/CategoryProductSeeder.php
+++ b/database/seeders/CategoryProductSeeder.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class CategoryProductSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categoryTree = [
+            'Electronics & Gadgets' => [
+                'Smartphones & Tablets' => 12,
+                'Computers & Laptops' => 10,
+                'Audio & Headphones' => 8,
+            ],
+            'Home, Garden & DIY' => [
+                'Kitchen Appliances' => 9,
+                'Furniture & Decor' => 7,
+                'Tools & Home Improvement' => 6,
+            ],
+            'Sports & Outdoor' => [
+                'Fitness & Training' => 8,
+                'Cycling & Mobility' => 6,
+                'Camping & Hiking' => 6,
+            ],
+        ];
+
+        foreach ($categoryTree as $rootName => $children) {
+            $rootCategory = Category::factory()
+                ->active()
+                ->create([
+                    'name' => $rootName,
+                    'slug' => Str::slug($rootName),
+                    'parent_id' => null,
+                ]);
+
+            Product::factory()
+                ->count(3)
+                ->active()
+                ->pricedBetween(150000, 650000)
+                ->for($rootCategory)
+                ->state(new Sequence(
+                    ['currency' => 'AMD'],
+                    ['currency' => 'USD'],
+                    ['currency' => 'EUR'],
+                ))
+                ->create();
+
+            foreach ($children as $childName => $productCount) {
+                $childCategory = Category::factory()
+                    ->active()
+                    ->childOf($rootCategory)
+                    ->create([
+                        'name' => $childName,
+                        'slug' => Str::slug($rootName.'-'.$childName),
+                    ]);
+
+                Product::factory()
+                    ->count(max(1, $productCount - 1))
+                    ->active()
+                    ->pricedBetween(10000, 350000)
+                    ->for($childCategory)
+                    ->state(new Sequence(
+                        ['currency' => 'AMD'],
+                        ['currency' => 'USD'],
+                        ['currency' => 'AMD'],
+                        ['currency' => 'EUR'],
+                    ))
+                    ->create();
+
+                Product::factory()
+                    ->inactive()
+                    ->lowStock()
+                    ->inCurrency('AMD')
+                    ->for($childCategory)
+                    ->create();
+            }
+
+            Category::factory()
+                ->inactive()
+                ->childOf($rootCategory)
+                ->create([
+                    'name' => $rootName.' Clearance',
+                    'slug' => Str::slug($rootName.'-clearance'),
+                ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,7 +13,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call([
+            CategoryProductSeeder::class,
+        ]);
 
         User::factory()->create([
             'name' => 'Test User',


### PR DESCRIPTION
## Summary
- extend the category and product factories with reusable states for active, inactive, stock, price and currency customisation
- add a dedicated seeder that builds a nested category tree and populates each node with varied product data
- hook the new seeder into the application seeding pipeline alongside the sample user

## Testing
- not run (vendor directory not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e17db10f34833098fb847984751b07