### PR TITLE
Add Blade CRUD interfaces for categories and products

### DIFF
--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -25,7 +25,7 @@ class CategoryController extends Controller
         $perPage = (int) $request->integer('per_page', 15);
         $perPage = max(1, min($perPage, 100));
 
-        $categories = $this->categoryService->paginate($perPage);
+        $categories = $this->categoryService->paginate([], $perPage);
 
         return CategoryResource::collection($categories);
     }

--- a/app/Http/Controllers/Web/CategoryWebController.php
+++ b/app/Http/Controllers/Web/CategoryWebController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers\Web;
+
+use App\DTO\Category\StoreCategoryDto;
+use App\DTO\Category\UpdateCategoryDto;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Category\StoreCategoryRequest;
+use App\Http\Requests\Category\UpdateCategoryRequest;
+use App\Models\Category;
+use App\Services\CategoryService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class CategoryWebController extends Controller
+{
+    public function __construct(private readonly CategoryService $categoryService)
+    {
+    }
+
+    public function index(Request $request): View
+    {
+        $perPage = (int) $request->integer('per_page', 15);
+        $perPage = max(1, min($perPage, 100));
+
+        $filters = [
+            'search' => $request->string('search')->toString(),
+            'parent_id' => $request->filled('parent_id') ? (int) $request->input('parent_id') : null,
+        ];
+
+        if ($request->has('is_active')) {
+            $filters['is_active'] = $request->input('is_active');
+        }
+
+        $filters = array_filter($filters, static fn ($value) => $value !== null && $value !== '');
+
+        $categories = $this->categoryService->paginate($filters, $perPage);
+
+        $parentOptions = $this->categoryService->activeList()
+            ->pluck('name', 'id')
+            ->toArray();
+
+        $viewFilters = [
+            'search' => $request->query('search', ''),
+            'is_active' => $request->query('is_active', ''),
+            'parent_id' => $request->query('parent_id', ''),
+            'per_page' => $perPage,
+        ];
+
+        return view('categories.index', [
+            'categories' => $categories,
+            'filters' => $viewFilters,
+            'parentOptions' => $parentOptions,
+        ]);
+    }
+
+    public function create(): View
+    {
+        $category = Category::make(['is_active' => true]);
+
+        $categoriesForSelect = $this->categoryService->activeList()
+            ->pluck('name', 'id')
+            ->toArray();
+
+        return view('categories.create', [
+            'category' => $category,
+            'categoriesForSelect' => $categoriesForSelect,
+        ]);
+    }
+
+    public function store(StoreCategoryRequest $request): RedirectResponse
+    {
+        $dto = StoreCategoryDto::fromRequest($request);
+        $category = $this->categoryService->create($dto);
+
+        return redirect()
+            ->route('categories.show', $category)
+            ->with('success', __('Category created successfully.'));
+    }
+
+    public function show(Category $category): View
+    {
+        $category->load(['parent']);
+
+        return view('categories.show', [
+            'category' => $category,
+        ]);
+    }
+
+    public function edit(Category $category): View
+    {
+        $category->load('parent');
+
+        $categoriesForSelect = $this->categoryService->activeList()
+            ->reject(fn (Category $item) => $item->id === $category->id)
+            ->pluck('name', 'id')
+            ->toArray();
+
+        return view('categories.edit', [
+            'category' => $category,
+            'categoriesForSelect' => $categoriesForSelect,
+        ]);
+    }
+
+    public function update(UpdateCategoryRequest $request, Category $category): RedirectResponse
+    {
+        $dto = UpdateCategoryDto::fromRequest($request, $category);
+        $updated = $this->categoryService->update($category, $dto);
+
+        return redirect()
+            ->route('categories.show', $updated)
+            ->with('success', __('Category updated successfully.'));
+    }
+
+    public function destroy(Category $category): RedirectResponse
+    {
+        $this->categoryService->delete($category);
+
+        return redirect()
+            ->route('categories.index')
+            ->with('success', __('Category deleted successfully.'));
+    }
+}

--- a/app/Http/Controllers/Web/ProductWebController.php
+++ b/app/Http/Controllers/Web/ProductWebController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers\Web;
+
+use App\DTO\Product\StoreProductDto;
+use App\DTO\Product\UpdateProductDto;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Product\StoreProductRequest;
+use App\Http\Requests\Product\UpdateProductRequest;
+use App\Models\Product;
+use App\Services\CategoryService;
+use App\Services\ProductService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ProductWebController extends Controller
+{
+    public function __construct(
+        private readonly ProductService $productService,
+        private readonly CategoryService $categoryService,
+    ) {
+    }
+
+    public function index(Request $request): View
+    {
+        $perPage = (int) $request->integer('per_page', 15);
+        $perPage = max(1, min($perPage, 100));
+
+        $filters = [
+            'search' => $request->string('search')->toString(),
+            'category_id' => $request->filled('category_id') ? (int) $request->input('category_id') : null,
+            'price_min' => $request->filled('price_min') ? $request->input('price_min') : null,
+            'price_max' => $request->filled('price_max') ? $request->input('price_max') : null,
+            'sort' => $request->query('sort'),
+        ];
+
+        if ($request->has('is_active')) {
+            $filters['is_active'] = $request->input('is_active');
+        }
+
+        $filters = array_filter($filters, static fn ($value) => $value !== null && $value !== '');
+
+        $products = $this->productService->paginate($filters, $perPage);
+
+        $categoryOptions = $this->categoryService->activeList()
+            ->pluck('name', 'id')
+            ->toArray();
+
+        $sortOptions = [
+            'name' => __('Name (A-Z)'),
+            '-price' => __('Price (high to low)'),
+            '-created_at' => __('Newest first'),
+        ];
+
+        $viewFilters = [
+            'search' => $request->query('search', ''),
+            'category_id' => $request->query('category_id', ''),
+            'is_active' => $request->query('is_active', ''),
+            'price_min' => $request->query('price_min', ''),
+            'price_max' => $request->query('price_max', ''),
+            'sort' => $request->query('sort', ''),
+            'per_page' => $perPage,
+        ];
+
+        return view('products.index', [
+            'products' => $products,
+            'filters' => $viewFilters,
+            'categoryOptions' => $categoryOptions,
+            'sortOptions' => $sortOptions,
+        ]);
+    }
+
+    public function create(): View
+    {
+        $product = Product::make([
+            'is_active' => true,
+            'currency' => 'AMD',
+            'quantity' => 0,
+        ]);
+
+        $categoriesForSelect = $this->categoryService->activeList()
+            ->pluck('name', 'id')
+            ->toArray();
+
+        return view('products.create', [
+            'product' => $product,
+            'categoriesForSelect' => $categoriesForSelect,
+        ]);
+    }
+
+    public function store(StoreProductRequest $request): RedirectResponse
+    {
+        $dto = StoreProductDto::fromRequest($request);
+        $product = $this->productService->create($dto);
+
+        return redirect()
+            ->route('products.show', $product)
+            ->with('success', __('Product created successfully.'));
+    }
+
+    public function show(Product $product): View
+    {
+        $product->load('category');
+
+        return view('products.show', [
+            'product' => $product,
+        ]);
+    }
+
+    public function edit(Product $product): View
+    {
+        $product->load('category');
+
+        $categories = $this->categoryService->activeList();
+        if ($product->category && !$categories->contains('id', $product->category_id)) {
+            $categories->push($product->category);
+            $categories = $categories->sortBy('name');
+        }
+
+        $categoriesForSelect = $categories
+            ->pluck('name', 'id')
+            ->toArray();
+
+        return view('products.edit', [
+            'product' => $product,
+            'categoriesForSelect' => $categoriesForSelect,
+        ]);
+    }
+
+    public function update(UpdateProductRequest $request, Product $product): RedirectResponse
+    {
+        $dto = UpdateProductDto::fromRequest($request, $product);
+        $updated = $this->productService->update($product, $dto);
+
+        return redirect()
+            ->route('products.show', $updated)
+            ->with('success', __('Product updated successfully.'));
+    }
+
+    public function destroy(Product $product): RedirectResponse
+    {
+        $this->productService->delete($product);
+
+        return redirect()
+            ->route('products.index')
+            ->with('success', __('Product deleted successfully.'));
+    }
+}

--- a/app/Repositories/Interfaces/CategoryRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CategoryRepositoryInterface.php
@@ -6,10 +6,13 @@ use App\DTO\Category\StoreCategoryDto;
 use App\DTO\Category\UpdateCategoryDto;
 use App\Models\Category;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 
 interface CategoryRepositoryInterface
 {
     public function paginate(int $perPage = 15): LengthAwarePaginator;
+
+    public function filterPaginate(array $filters, int $perPage = 15): LengthAwarePaginator;
 
     public function findById(int $id): Category;
 
@@ -23,4 +26,9 @@ interface CategoryRepositoryInterface
      * @return array<int, mixed>
      */
     public function tree(): array;
+
+    /**
+     * @return Collection<int, Category>
+     */
+    public function getActiveList(): Collection;
 }

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -7,6 +7,7 @@ use App\DTO\Category\UpdateCategoryDto;
 use App\Models\Category;
 use App\Repositories\Interfaces\CategoryRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 
 class CategoryService
@@ -15,9 +16,13 @@ class CategoryService
     {
     }
 
-    public function paginate(int $perPage = 15): LengthAwarePaginator
+    public function paginate(array $filters = [], int $perPage = 15): LengthAwarePaginator
     {
-        return $this->categoryRepository->paginate($perPage);
+        if ($filters === []) {
+            return $this->categoryRepository->paginate($perPage);
+        }
+
+        return $this->categoryRepository->filterPaginate($filters, $perPage);
     }
 
     public function find(int $id): Category
@@ -64,6 +69,14 @@ class CategoryService
     public function tree(): array
     {
         return $this->categoryRepository->tree();
+    }
+
+    /**
+     * @return Collection<int, Category>
+     */
+    public function activeList(): Collection
+    {
+        return $this->categoryRepository->getActiveList();
     }
 
     private function prepareSlug(?string $slug, string $name, ?int $ignoreId = null): string

--- a/resources/views/categories/_form.blade.php
+++ b/resources/views/categories/_form.blade.php
@@ -1,0 +1,34 @@
+@php
+    /** @var \App\Models\Category $category */
+    $parentOptions = $categoriesForSelect ?? [];
+@endphp
+
+<div class="grid gap-4 sm:grid-cols-2">
+    <x-form.input
+        name="name"
+        :value="$category->name"
+        label="{{ __('Name') }}"
+        required
+    />
+    <x-form.input
+        name="slug"
+        :value="$category->slug"
+        label="{{ __('Slug') }}"
+        placeholder="{{ __('Auto-generated if empty') }}"
+    />
+</div>
+<div class="grid gap-4 sm:grid-cols-2 mt-4">
+    <x-form.select
+        name="parent_id"
+        :value="$category->parent_id"
+        label="{{ __('Parent category') }}"
+        :options="$parentOptions"
+        placeholder="{{ __('No parent') }}"
+    />
+    <x-form.select
+        name="is_active"
+        :value="$category->is_active ?? true"
+        label="{{ __('Status') }}"
+        :options="[1 => __('Active'), 0 => __('Inactive')]"
+    />
+</div>

--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('categories.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Categories') }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ __('Create') }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <h1 class="text-xl font-semibold text-gray-800">{{ __('Create category') }}</h1>
+        <form action="{{ route('categories.store') }}" method="POST" class="mt-6 space-y-6">
+            @csrf
+            @include('categories._form', ['category' => $category, 'categoriesForSelect' => $categoriesForSelect])
+
+            <div class="flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Save') }}
+                </button>
+                <a href="{{ route('categories.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Cancel') }}
+                </a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('categories.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Categories') }}</a>
+        <span class="mx-2">/</span>
+        <a href="{{ route('categories.show', $category) }}" class="text-indigo-600 hover:text-indigo-800">{{ $category->name }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ __('Edit') }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <h1 class="text-xl font-semibold text-gray-800">{{ __('Edit category') }}</h1>
+        <form action="{{ route('categories.update', $category) }}" method="POST" class="mt-6 space-y-6">
+            @csrf
+            @method('PATCH')
+            @include('categories._form', ['category' => $category, 'categoriesForSelect' => $categoriesForSelect])
+
+            <div class="flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Save changes') }}
+                </button>
+                <a href="{{ route('categories.show', $category) }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Cancel') }}
+                </a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,0 +1,102 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-800">{{ __('Categories') }}</h1>
+        <a href="{{ route('categories.create') }}" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+            {{ __('Create category') }}
+        </a>
+    </div>
+
+    <div class="mt-6 rounded-lg bg-white p-6 shadow">
+        <form method="GET" action="{{ route('categories.index') }}" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <x-form.input
+                name="search"
+                label="{{ __('Search') }}"
+                :value="$filters['search'] ?? ''"
+                placeholder="{{ __('Name or slug') }}"
+            />
+            <x-form.select
+                name="is_active"
+                label="{{ __('Status') }}"
+                :value="$filters['is_active'] ?? ''"
+                :options="['1' => __('Active'), '0' => __('Inactive')]"
+                placeholder="{{ __('Any status') }}"
+            />
+            <x-form.select
+                name="parent_id"
+                label="{{ __('Parent category') }}"
+                :value="$filters['parent_id'] ?? ''"
+                :options="$parentOptions"
+                placeholder="{{ __('Any parent') }}"
+            />
+            <x-form.select
+                name="per_page"
+                label="{{ __('Per page') }}"
+                :value="$filters['per_page'] ?? 15"
+                :options="[10 => 10, 15 => 15, 25 => 25, 50 => 50]"
+            />
+            <div class="sm:col-span-2 lg:col-span-4 flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Filter') }}
+                </button>
+                <a href="{{ route('categories.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Reset') }}
+                </a>
+            </div>
+        </form>
+    </div>
+
+    <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('ID') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Name') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Slug') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Parent') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Status') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Created at') }}</th>
+                    <th class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Actions') }}</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+                @forelse ($categories as $category)
+                    <tr>
+                        <td class="px-4 py-3 text-sm text-gray-900">{{ $category->id }}</td>
+                        <td class="px-4 py-3 text-sm font-medium text-indigo-600">{{ $category->name }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $category->slug }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $category->parent?->name ?? __('—') }}</td>
+                        <td class="px-4 py-3 text-sm">
+                            @if ($category->is_active)
+                                <span class="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">{{ __('Active') }}</span>
+                            @else
+                                <span class="inline-flex rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">{{ __('Inactive') }}</span>
+                            @endif
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $category->created_at?->format('Y-m-d H:i') }}</td>
+                        <td class="px-4 py-3 text-right text-sm">
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('categories.show', $category) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('View') }}</a>
+                                <a href="{{ route('categories.edit', $category) }}" class="text-amber-600 hover:text-amber-800">{{ __('Edit') }}</a>
+                                <form method="POST" action="{{ route('categories.destroy', $category) }}" onsubmit="return confirm('{{ __('Are you sure you want to delete this category?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Delete') }}</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="px-4 py-6 text-center text-sm text-gray-500">{{ __('No categories found.') }}</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $categories->withQueryString()->links() }}
+    </div>
+@endsection

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('categories.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Categories') }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ $category->name }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <div class="flex items-start justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-800">{{ $category->name }}</h1>
+                <p class="mt-1 text-sm text-gray-500">{{ __('Slug') }}: {{ $category->slug ?? __('—') }}</p>
+            </div>
+            <div class="flex items-center gap-2">
+                <a href="{{ route('categories.edit', $category) }}" class="inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 hover:bg-amber-100">
+                    {{ __('Edit') }}
+                </a>
+                <form method="POST" action="{{ route('categories.destroy', $category) }}" onsubmit="return confirm('{{ __('Are you sure you want to delete this category?') }}');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="inline-flex items-center rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-100">
+                        {{ __('Delete') }}
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <dl class="mt-6 grid gap-4 sm:grid-cols-2">
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Parent category') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $category->parent?->name ?? __('—') }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Status') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                    @if ($category->is_active)
+                        <span class="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">{{ __('Active') }}</span>
+                    @else
+                        <span class="inline-flex rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">{{ __('Inactive') }}</span>
+                    @endif
+                </dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Created at') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $category->created_at?->format('Y-m-d H:i') ?? __('—') }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Updated at') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $category->updated_at?->format('Y-m-d H:i') ?? __('—') }}</dd>
+            </div>
+        </dl>
+
+        <div class="mt-6">
+            <a href="{{ route('categories.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                {{ __('Back to list') }}
+            </a>
+        </div>
+    </div>
+@endsection

--- a/resources/views/components/flash.blade.php
+++ b/resources/views/components/flash.blade.php
@@ -1,0 +1,22 @@
+@if (session('success'))
+    <div class="mb-4 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+        {{ session('success') }}
+    </div>
+@endif
+
+@if (session('error'))
+    <div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+        {{ session('error') }}
+    </div>
+@endif
+
+@if ($errors->any())
+    <div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+        <p class="font-semibold">{{ __('Please fix the following errors:') }}</p>
+        <ul class="mt-2 list-disc space-y-1 pl-5">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/components/form/input.blade.php
+++ b/resources/views/components/form/input.blade.php
@@ -1,0 +1,34 @@
+@props([
+    'name',
+    'label',
+    'type' => 'text',
+    'value' => null,
+    'required' => false,
+    'placeholder' => null,
+])
+
+@php
+    $fieldId = $attributes->get('id', $name);
+    $fieldValue = old($name, $value);
+@endphp
+
+<div>
+    <label for="{{ $fieldId }}" class="block text-sm font-medium text-gray-700">
+        {{ $label }}
+        @if($required)
+            <span class="text-red-500">*</span>
+        @endif
+    </label>
+    <input
+        id="{{ $fieldId }}"
+        name="{{ $name }}"
+        type="{{ $type }}"
+        value="{{ $fieldValue }}"
+        @if($placeholder) placeholder="{{ $placeholder }}" @endif
+        {{ $attributes->merge(['class' => 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm']) }}
+        @if($required) required @endif
+    >
+    @error($name)
+        <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/components/form/select.blade.php
+++ b/resources/views/components/form/select.blade.php
@@ -1,0 +1,40 @@
+@props([
+    'name',
+    'label',
+    'options' => [],
+    'value' => null,
+    'placeholder' => null,
+    'required' => false,
+])
+
+@php
+    $fieldId = $attributes->get('id', $name);
+    $fieldValue = old($name, $value);
+@endphp
+
+<div>
+    <label for="{{ $fieldId }}" class="block text-sm font-medium text-gray-700">
+        {{ $label }}
+        @if($required)
+            <span class="text-red-500">*</span>
+        @endif
+    </label>
+    <select
+        id="{{ $fieldId }}"
+        name="{{ $name }}"
+        {{ $attributes->merge(['class' => 'mt-1 block w-full rounded-md border-gray-300 bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm']) }}
+        @if($required) required @endif
+    >
+        @if($placeholder)
+            <option value="">{{ $placeholder }}</option>
+        @endif
+        @foreach($options as $optionValue => $optionLabel)
+            <option value="{{ $optionValue }}" @selected((string) $fieldValue === (string) $optionValue)>
+                {{ $optionLabel }}
+            </option>
+        @endforeach
+    </select>
+    @error($name)
+        <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/components/form/textarea.blade.php
+++ b/resources/views/components/form/textarea.blade.php
@@ -1,0 +1,33 @@
+@props([
+    'name',
+    'label',
+    'value' => null,
+    'rows' => 4,
+    'placeholder' => null,
+    'required' => false,
+])
+
+@php
+    $fieldId = $attributes->get('id', $name);
+    $fieldValue = old($name, $value);
+@endphp
+
+<div>
+    <label for="{{ $fieldId }}" class="block text-sm font-medium text-gray-700">
+        {{ $label }}
+        @if($required)
+            <span class="text-red-500">*</span>
+        @endif
+    </label>
+    <textarea
+        id="{{ $fieldId }}"
+        name="{{ $name }}"
+        rows="{{ $rows }}"
+        @if($placeholder) placeholder="{{ $placeholder }}" @endif
+        {{ $attributes->merge(['class' => 'mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm']) }}
+        @if($required) required @endif
+    >{{ $fieldValue }}</textarea>
+    @error($name)
+        <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+    @enderror
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name', 'Laravel') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-100 text-gray-900 min-h-screen">
+    <header class="bg-white shadow">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+            <a href="{{ route('categories.index') }}" class="text-lg font-semibold text-indigo-600">
+                {{ config('app.name', __('Dashboard')) }}
+            </a>
+            <nav class="space-x-4">
+                <a href="{{ route('categories.index') }}" class="inline-flex items-center px-3 py-2 rounded-md text-sm font-medium {{ request()->routeIs('categories.*') ? 'bg-indigo-100 text-indigo-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100' }}">
+                    {{ __('Categories') }}
+                </a>
+                <a href="{{ route('products.index') }}" class="inline-flex items-center px-3 py-2 rounded-md text-sm font-medium {{ request()->routeIs('products.*') ? 'bg-indigo-100 text-indigo-700' : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100' }}">
+                    {{ __('Products') }}
+                </a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        @include('components.flash')
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/resources/views/products/_form.blade.php
+++ b/resources/views/products/_form.blade.php
@@ -1,0 +1,82 @@
+@php
+    /** @var \App\Models\Product $product */
+    $categoryOptions = $categoriesForSelect ?? [];
+    $currencyOptions = ['AMD' => 'AMD', 'USD' => 'USD', 'EUR' => 'EUR'];
+@endphp
+
+<div class="grid gap-4 sm:grid-cols-2">
+    <x-form.select
+        name="category_id"
+        :value="$product->category_id"
+        label="{{ __('Category') }}"
+        :options="$categoryOptions"
+        placeholder="{{ __('Select category') }}"
+        required
+    />
+    <x-form.input
+        name="name"
+        :value="$product->name"
+        label="{{ __('Name') }}"
+        required
+    />
+</div>
+
+<div class="grid gap-4 sm:grid-cols-2 mt-4">
+    <x-form.input
+        name="slug"
+        :value="$product->slug"
+        label="{{ __('Slug') }}"
+        placeholder="{{ __('Auto-generated if empty') }}"
+    />
+    <x-form.input
+        name="sku"
+        :value="$product->sku"
+        label="{{ __('SKU') }}"
+        required
+    />
+</div>
+
+<div class="grid gap-4 sm:grid-cols-3 mt-4">
+    <x-form.input
+        name="price"
+        type="number"
+        step="0.01"
+        min="0"
+        :value="$product->price"
+        label="{{ __('Price') }}"
+        required
+    />
+    <x-form.select
+        name="currency"
+        :value="$product->currency ?? 'AMD'"
+        label="{{ __('Currency') }}"
+        :options="$currencyOptions"
+        required
+    />
+    <x-form.input
+        name="quantity"
+        type="number"
+        min="0"
+        :value="$product->quantity ?? 0"
+        label="{{ __('Quantity') }}"
+    />
+</div>
+
+<div class="grid gap-4 sm:grid-cols-2 mt-4">
+    <x-form.select
+        name="is_active"
+        :value="$product->is_active ?? true"
+        label="{{ __('Status') }}"
+        :options="[1 => __('Active'), 0 => __('Inactive')]"
+    />
+</div>
+
+<div class="mt-4">
+    <x-form.textarea
+        name="description"
+        :value="$product->description"
+        label="{{ __('Description') }}"
+        rows="5"
+        placeholder="{{ __('Describe the product...') }}"
+    />
+</div>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('products.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Products') }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ __('Create') }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <h1 class="text-xl font-semibold text-gray-800">{{ __('Create product') }}</h1>
+        <form action="{{ route('products.store') }}" method="POST" class="mt-6 space-y-6">
+            @csrf
+            @include('products._form', ['product' => $product, 'categoriesForSelect' => $categoriesForSelect])
+
+            <div class="flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Save') }}
+                </button>
+                <a href="{{ route('products.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Cancel') }}
+                </a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('products.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Products') }}</a>
+        <span class="mx-2">/</span>
+        <a href="{{ route('products.show', $product) }}" class="text-indigo-600 hover:text-indigo-800">{{ $product->name }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ __('Edit') }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <h1 class="text-xl font-semibold text-gray-800">{{ __('Edit product') }}</h1>
+        <form action="{{ route('products.update', $product) }}" method="POST" class="mt-6 space-y-6">
+            @csrf
+            @method('PATCH')
+            @include('products._form', ['product' => $product, 'categoriesForSelect' => $categoriesForSelect])
+
+            <div class="flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Save changes') }}
+                </button>
+                <a href="{{ route('products.show', $product) }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Cancel') }}
+                </a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,131 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="flex items-center justify-between">
+        <h1 class="text-2xl font-semibold text-gray-800">{{ __('Products') }}</h1>
+        <a href="{{ route('products.create') }}" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+            {{ __('Create product') }}
+        </a>
+    </div>
+
+    <div class="mt-6 rounded-lg bg-white p-6 shadow">
+        <form method="GET" action="{{ route('products.index') }}" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <x-form.input
+                name="search"
+                label="{{ __('Search') }}"
+                :value="$filters['search'] ?? ''"
+                placeholder="{{ __('Name, SKU or slug') }}"
+            />
+            <x-form.select
+                name="category_id"
+                label="{{ __('Category') }}"
+                :value="$filters['category_id'] ?? ''"
+                :options="$categoryOptions"
+                placeholder="{{ __('Any category') }}"
+            />
+            <x-form.select
+                name="is_active"
+                label="{{ __('Status') }}"
+                :value="$filters['is_active'] ?? ''"
+                :options="['1' => __('Active'), '0' => __('Inactive')]"
+                placeholder="{{ __('Any status') }}"
+            />
+            <x-form.select
+                name="sort"
+                label="{{ __('Sort by') }}"
+                :value="$filters['sort'] ?? ''"
+                :options="$sortOptions"
+                placeholder="{{ __('Default') }}"
+            />
+            <x-form.input
+                name="price_min"
+                type="number"
+                step="0.01"
+                min="0"
+                label="{{ __('Min price') }}"
+                :value="$filters['price_min'] ?? ''"
+            />
+            <x-form.input
+                name="price_max"
+                type="number"
+                step="0.01"
+                min="0"
+                label="{{ __('Max price') }}"
+                :value="$filters['price_max'] ?? ''"
+            />
+            <x-form.select
+                name="per_page"
+                label="{{ __('Per page') }}"
+                :value="$filters['per_page'] ?? 15"
+                :options="[10 => 10, 15 => 15, 25 => 25, 50 => 50]"
+            />
+            <div class="sm:col-span-2 lg:col-span-4 flex items-center gap-3">
+                <button type="submit" class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700">
+                    {{ __('Filter') }}
+                </button>
+                <a href="{{ route('products.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                    {{ __('Reset') }}
+                </a>
+            </div>
+        </form>
+    </div>
+
+    <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('ID') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Name') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('SKU') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Price') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Quantity') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Category') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Status') }}</th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Created at') }}</th>
+                    <th class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">{{ __('Actions') }}</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+                @forelse ($products as $product)
+                    <tr>
+                        <td class="px-4 py-3 text-sm text-gray-900">{{ $product->id }}</td>
+                        <td class="px-4 py-3 text-sm font-medium text-indigo-600">{{ $product->name }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $product->sku }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">
+                            {{ number_format($product->price, 2) }} {{ $product->currency }}
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $product->quantity }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $product->category?->name ?? __('—') }}</td>
+                        <td class="px-4 py-3 text-sm">
+                            @if ($product->is_active)
+                                <span class="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">{{ __('Active') }}</span>
+                            @else
+                                <span class="inline-flex rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">{{ __('Inactive') }}</span>
+                            @endif
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-500">{{ $product->created_at?->format('Y-m-d H:i') }}</td>
+                        <td class="px-4 py-3 text-right text-sm">
+                            <div class="flex items-center justify-end gap-2">
+                                <a href="{{ route('products.show', $product) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('View') }}</a>
+                                <a href="{{ route('products.edit', $product) }}" class="text-amber-600 hover:text-amber-800">{{ __('Edit') }}</a>
+                                <form method="POST" action="{{ route('products.destroy', $product) }}" onsubmit="return confirm('{{ __('Are you sure you want to delete this product?') }}');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:text-red-800">{{ __('Delete') }}</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="9" class="px-4 py-6 text-center text-sm text-gray-500">{{ __('No products found.') }}</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $products->withQueryString()->links() }}
+    </div>
+@endsection

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('content')
+    <nav class="mb-4 text-sm text-gray-500">
+        <a href="{{ route('products.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('Products') }}</a>
+        <span class="mx-2">/</span>
+        <span>{{ $product->name }}</span>
+    </nav>
+
+    <div class="rounded-lg bg-white p-6 shadow">
+        <div class="flex items-start justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-800">{{ $product->name }}</h1>
+                <p class="mt-1 text-sm text-gray-500">{{ __('SKU') }}: {{ $product->sku }}</p>
+            </div>
+            <div class="flex items-center gap-2">
+                <a href="{{ route('products.edit', $product) }}" class="inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm font-medium text-amber-700 hover:bg-amber-100">
+                    {{ __('Edit') }}
+                </a>
+                <form method="POST" action="{{ route('products.destroy', $product) }}" onsubmit="return confirm('{{ __('Are you sure you want to delete this product?') }}');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="inline-flex items-center rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-100">
+                        {{ __('Delete') }}
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <dl class="mt-6 grid gap-4 sm:grid-cols-2">
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Slug') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $product->slug ?? __('—') }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Category') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $product->category?->name ?? __('—') }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Price') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ number_format($product->price, 2) }} {{ $product->currency }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Quantity') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $product->quantity }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Status') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">
+                    @if ($product->is_active)
+                        <span class="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">{{ __('Active') }}</span>
+                    @else
+                        <span class="inline-flex rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">{{ __('Inactive') }}</span>
+                    @endif
+                </dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Created at') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $product->created_at?->format('Y-m-d H:i') ?? __('—') }}</dd>
+            </div>
+            <div class="rounded-lg border border-gray-200 p-4">
+                <dt class="text-sm font-medium text-gray-500">{{ __('Updated at') }}</dt>
+                <dd class="mt-1 text-sm text-gray-900">{{ $product->updated_at?->format('Y-m-d H:i') ?? __('—') }}</dd>
+            </div>
+        </dl>
+
+        @if ($product->description)
+            <div class="mt-6 rounded-lg border border-gray-200 p-4">
+                <h2 class="text-sm font-semibold text-gray-600">{{ __('Description') }}</h2>
+                <p class="mt-2 text-sm text-gray-700 whitespace-pre-line">{{ $product->description }}</p>
+            </div>
+        @endif
+
+        <div class="mt-6">
+            <a href="{{ route('products.index') }}" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
+                {{ __('Back to list') }}
+            </a>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Http\Controllers\Web\CategoryWebController;
+use App\Http\Controllers\Web\ProductWebController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', fn () => redirect()->route('categories.index'));
+
+Route::resource('categories', CategoryWebController::class);
+Route::resource('products', ProductWebController::class);

--- a/tests/Feature/Web/CategoryWebControllerTest.php
+++ b/tests/Feature/Web/CategoryWebControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CategoryWebControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_displays_categories(): void
+    {
+        Category::factory()->create();
+
+        $response = $this->get(route('categories.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('categories.index');
+    }
+
+    public function test_store_creates_category(): void
+    {
+        $parent = Category::factory()->create();
+
+        $response = $this->post(route('categories.store'), [
+            'name' => 'New Category',
+            'slug' => 'new-category',
+            'parent_id' => $parent->id,
+            'is_active' => 1,
+        ]);
+
+        $createdCategory = Category::where('name', 'New Category')->first();
+        self::assertNotNull($createdCategory);
+
+        $response->assertRedirect(route('categories.show', $createdCategory));
+        $this->assertDatabaseHas('categories', [
+            'name' => 'New Category',
+            'parent_id' => $parent->id,
+        ]);
+    }
+}

--- a/tests/Feature/Web/ProductWebControllerTest.php
+++ b/tests/Feature/Web/ProductWebControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Web;
+
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductWebControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_displays_products(): void
+    {
+        $category = Category::factory()->create();
+        Product::factory()->create(['category_id' => $category->id]);
+
+        $response = $this->get(route('products.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('products.index');
+    }
+
+    public function test_store_creates_product(): void
+    {
+        $category = Category::factory()->create();
+
+        $response = $this->post(route('products.store'), [
+            'category_id' => $category->id,
+            'name' => 'Test product',
+            'slug' => 'test-product',
+            'sku' => 'SKU12345',
+            'price' => 199.99,
+            'currency' => 'USD',
+            'quantity' => 5,
+            'is_active' => 1,
+            'description' => 'Short description',
+        ]);
+
+        $createdProduct = Product::where('sku', 'SKU12345')->first();
+        self::assertNotNull($createdProduct);
+
+        $response->assertRedirect(route('products.show', $createdProduct));
+        $this->assertDatabaseHas('products', [
+            'sku' => 'SKU12345',
+            'category_id' => $category->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add web controllers for category and product CRUD backed by existing services
- build Blade layout, form components, and CRUD pages with filtering, sorting, and pagination
- cover routes and new UI with feature tests exercising basic flows

## Testing
- not run (composer install requires GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1807a58bc8330b12de1926f24ea81