### PR TITLE
Fix Vite CSS asset reference

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ config('app.name', 'Laravel') }}</title>
-    @vite(['resources/scss/app.scss','resources/js/app.js'])
+    @vite(['resources/css/app.css','resources/js/app.js'])
 </head>
 <body class="app-gradient d-flex flex-column">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark bg-opacity-75 sticky-top shadow-sm" style="backdrop-filter: blur(12px);">

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import laravel from 'laravel-vite-plugin';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/scss/app.scss', 'resources/js/app.js'],
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
     ],


### PR DESCRIPTION
## Summary
- update the main layout to load the compiled CSS entry that already exists in the Vite manifest
- align the Vite configuration inputs with the CSS and JS assets that are built for the application

## Testing
- npm run build *(fails: bootstrap dependency is unavailable in the offline environment, so Rollup cannot resolve it)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d2e71108330a0f346639d6596a1