### PR TITLE
Add CDN fallback when Vite manifest is missing

### DIFF
--- a/public/css/app-fallback.css
+++ b/public/css/app-fallback.css
@@ -1,0 +1,50 @@
+:root {
+  --bs-border-radius: 1rem;
+  --bs-border-radius-lg: 1rem;
+  --bs-border-radius-sm: 0.75rem;
+  --bs-btn-border-radius: 0.75rem;
+  --bs-table-striped-bg: #f8f9fa;
+  --bs-body-bg: #f3f4f6;
+  --bs-body-color: #111827;
+  --bs-link-color: #0d6efd;
+}
+
+body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.app-gradient {
+  min-height: 100vh;
+  background:
+    radial-gradient(1200px 600px at 20% 0%, rgba(255, 255, 255, 0.12) 0%, transparent 60%),
+    linear-gradient(135deg, #8a2be2 0%, #ff00a8 100%);
+}
+
+.card-elevated {
+  box-shadow: 0 15px 40px rgba(16, 24, 40, 0.12);
+}
+
+.table-card thead th {
+  background: #2b2f36;
+  color: #fff;
+  border: 0;
+}
+
+.table-card tbody tr:hover {
+  background: #f1f3f5;
+}
+
+.toolbar .form-control,
+.toolbar .form-select {
+  min-width: 180px;
+}
+
+.btn-ghost {
+  color: #334155;
+}
+
+.btn-ghost:hover {
+  color: #111827;
+  background: #f1f5f9;
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,7 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ config('app.name', 'Laravel') }}</title>
-    @vite(['resources/scss/app.scss','resources/js/app.js'])
+    @php($hasViteBuild = file_exists(public_path('build/manifest.json')))
+    @if($hasViteBuild)
+        @vite(['resources/scss/app.scss', 'resources/js/app.js'])
+    @else
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-nkO9ZAg/P6nxsVXniPdwWh05rq6ArtyTc95xJMu38xpv8uKXu95syEHCLEwM1c8I" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{ asset('css/app-fallback.css') }}">
+    @endif
 </head>
 <body class="app-gradient d-flex flex-column">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark bg-opacity-75 sticky-top shadow-sm" style="backdrop-filter: blur(12px);">
@@ -38,5 +44,13 @@
             @yield('content')
         </div>
     </main>
+    @if(!$hasViteBuild)
+        <script src="https://cdn.jsdelivr.net/npm/axios@1.7.7/dist/axios.min.js" integrity="sha384-o8zCwyKdnFnLKZg2nc9mNsLAO6WkcRPu0Nl3JErw/+IwIgrJXuDSs2LaXpUPc0kV" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kk+1TGVtC6nwL5Tx5ONx5Oxb0uJg1Q7mh+g/hqdAOov2K7P+h/rk1cxO7jLaQjhj" crossorigin="anonymous" defer></script>
+        <script>
+            window.axios = window.axios || axios;
+            window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+        </script>
+    @endif
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect the absence of the Vite manifest and fall back to CDN-delivered Bootstrap and Axios assets
- add a lightweight CSS file that mirrors the custom styling previously provided by the Vite build

## Testing
- php artisan test *(fails: vendor directory not present in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a232de108330820ba4aa8ad194f3